### PR TITLE
feat: add `dind` to `deployment.yaml`

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -21,3 +21,20 @@ spec:
         
       imagePullSecrets:
         - name: {{ .Values.image.name }}-pull-secret
+
+      - name: dind
+        image: docker:18.09-dind
+        resources:
+          limits:
+            cpu: 750m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: dind-storage
+          mountPath: /var/lib/docker
+        - name: runner-work
+          mountPath: {{ .Values.runner.mountpath }}


### PR DESCRIPTION
### Description

I didn't completely finish this solution, but mostly for demonstration purposes to show that perhaps your `deployment.yaml` should include the `dind` sidecar so the self-hosted runner can run Docker actions.

I have something very similar in my runner right now and works pretty good!